### PR TITLE
Applying Bug fix PR 21250 from angular/core ngx-translate/i18n-polyfill

### DIFF
--- a/lib/src/serializers/xliff2.ts
+++ b/lib/src/serializers/xliff2.ts
@@ -28,6 +28,7 @@ const _NOTES_TAG = "notes";
 const _NOTE_TAG = "note";
 const _SEGMENT_TAG = "segment";
 const _FILE_TAG = "file";
+const _MARKER_TAG = 'mrk';
 
 // http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html
 export function xliff2LoadToI18n(content: string): I18nMessagesById {
@@ -262,6 +263,8 @@ class XmlToI18n implements ml.Visitor {
           );
         }
         break;
+        case _MARKER_TAG:
+          return ml.visitAll(this, el.children);
       default:
         this._addError(el, `Unexpected tag`);
     }


### PR DESCRIPTION
Applying bug fix [fix(compiler): add support for marker tags in xliff serializers #21250](https://github.com/angular/angular/pull/21250) from angular/core to ngx-translate/i18n-polyfill