### PR TITLE
Ability for translator to pick up functions not nested inside classes.

### DIFF
--- a/example/src/app/app.component.ts
+++ b/example/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import {Component} from "@angular/core";
 import {I18n} from "@ngx-translate/i18n-polyfill";
+import {Testing} from "../global";
 
 @Component({
   selector: "app-root",
@@ -16,5 +17,6 @@ export class AppComponent {
 
   test() {
     console.log(this.i18n("another test ^_^"));
+    console.log(Testing(this.i18n));
   }
 }

--- a/example/src/global.ts
+++ b/example/src/global.ts
@@ -1,0 +1,5 @@
+import { I18n } from "@ngx-translate/i18n-polyfill";
+
+export function Testing(i18nService: I18n): string {
+    return i18nService({ value: "Hello World", id: "Global1"});
+}

--- a/lib/extractor/src/extractor.ts
+++ b/lib/extractor/src/extractor.ts
@@ -59,6 +59,19 @@ export class ServiceParser extends AbstractAstParser {
       });
     });
 
+    const functionNodes = this._findFunctionNodes(this._sourceFile);
+    functionNodes.forEach(functionNode => {
+      const propertyName: string = this._findTranslateServicePropertyName(functionNode);
+      if (!propertyName) {
+        return;
+      }
+
+      const callNodes = this._findCallNodes(functionNode, propertyName);
+      callNodes.forEach(callNode => {
+        entries.push(...this._getCallArgStrings(callNode));
+      });
+    });
+
     return entries;
   }
 
@@ -66,7 +79,7 @@ export class ServiceParser extends AbstractAstParser {
    * Detect what the TranslateService instance property
    * is called by inspecting constructor arguments
    */
-  protected _findTranslateServicePropertyName(constructorNode: ts.ConstructorDeclaration): string {
+  protected _findTranslateServicePropertyName(constructorNode: ts.ConstructorDeclaration | ts.FunctionDeclaration): string {
     if (!constructorNode) {
       return null;
     }
@@ -102,6 +115,13 @@ export class ServiceParser extends AbstractAstParser {
    */
   protected _findClassNodes(node: ts.Node): ts.ClassDeclaration[] {
     return this._findNodes(node, ts.SyntaxKind.ClassDeclaration) as ts.ClassDeclaration[];
+  }
+
+  /**
+   * Find function nodes
+   */
+  protected _findFunctionNodes(node: ts.Node): ts.FunctionDeclaration[] {
+    return this._findNodes(node, ts.SyntaxKind.FunctionDeclaration) as ts.FunctionDeclaration[];
   }
 
   /**

--- a/test/extractor.spec.ts
+++ b/test/extractor.spec.ts
@@ -42,6 +42,13 @@ describe("Extractor", () => {
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
+      <trans-unit id=\"Global1\" datatype=\"html\">
+        <source>Hello World</source>
+        <context-group purpose=\"location\">
+          <context context-type=\"sourcefile\">example/src/global.ts</context>
+          <context context-type=\"linenumber\">1</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>
@@ -76,6 +83,13 @@ describe("Extractor", () => {
         <context-group purpose="location">
           <context context-type="sourcefile">example/src/app/app.component.ts</context>
           <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id=\"Global1\" datatype=\"html\">
+        <source>Hello World</source>
+        <context-group purpose=\"location\">
+          <context context-type=\"sourcefile\">example/src/global.ts</context>
+          <context context-type=\"linenumber\">1</context>
         </context-group>
       </trans-unit>
     </body>
@@ -132,6 +146,13 @@ describe("Extractor", () => {
         </context-group>
         <note priority="1" from="description">Custom desc</note>
         <note priority="1" from="meaning">Custom meaning</note>
+      </trans-unit>
+      <trans-unit id=\"Global1\" datatype=\"html\">
+        <source>Hello World</source>
+        <context-group purpose=\"location\">
+          <context context-type=\"sourcefile\">example/src/global.ts</context>
+          <context context-type=\"linenumber\">1</context>
+        </context-group>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Title. I use a few global common functions that are selectively imported into my components. I would like some of these functions to include translations. It currently isn't possible because the node scan only picks up on classes, then scans and sees if the constructor contains the I18n polyfill name. We can do the same thing for functions by scanning their parameters.