### PR TITLE
Add quotes to glob pattern in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The messages will be merged.
 The cli parameters are the following:
 - `--input` (alias: `-i`, required): Paths you would like to extract strings from. You can use path expansion, glob patterns and multiple paths.
   
-  Example: `-i src/**/*.ts`.
+  Example: `-i 'src/**/*.ts'`.
 
 - `--format` (alias `-f`, optional, default `xlf`): Output format, either xlf, xlf2 or xmb.
   
@@ -141,7 +141,7 @@ The cli parameters are the following:
 
 And here is how you would extract the messages from your ng cli application to a file named src/i18n/source.xlf:
 - run ng-xi18n: `ng xi18n -of i18n/source.xlf -f xlf --locale en`
-- run ng-extractor: `ngx-extractor -i src/**/*.ts -f xlf -o src/i18n/source.xlf`
+- run ng-extractor: `ngx-extractor -i 'src/**/*.ts' -f xlf -o src/i18n/source.xlf`
 
 ## Special thanks
 The service was written using source code from [Angular](https://github.com/angular/angular) and the extraction tool used code from [ngx-translate-extract](https://github.com/biesbjerg/ngx-translate-extract) by @biesbjerg.


### PR DESCRIPTION
Glob pattern doesn't work when not in quotes.
Maybe someone else also will have this issue.
Adds quotes.

This problem was already referenced in #2 and #6 .