### PR TITLE
update version yargs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/jest": "21.1.8",
     "@types/node": "8.0.54",
     "@types/prettier": "1.8.1",
-    "@types/yargs": "8.0.2",
+    "@types/yargs": "16.2.0",
     "codelyzer": "4.3.0",
     "commitizen": "2.9.6",
     "core-js": "2.5.1",
@@ -78,7 +78,7 @@
     "tslint-config-prettier": "1.6.0",
     "tslint-no-circular-imports": "0.2.0",
     "typescript": "~2.7.2",
-    "yargs": "^12.0.5",
+    "yargs": "^16.2.0",
     "zone.js": "0.8.18"
   },
   "config": {


### PR DESCRIPTION
it is necessary to update the version of yargs even so that the version of y18n is also updated, thus ruling out possible vulnerabilities.
yargs
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7608
y18n
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7774

